### PR TITLE
Up and down arrows replaced with matching characters

### DIFF
--- a/src/Components/CalendarInputTime.vue
+++ b/src/Components/CalendarInputTime.vue
@@ -12,12 +12,12 @@
       <span
         class="vdpr-datepicker__calendar-input-time-control-up"
         @click="onClickUp">
-      &#9652;
+      &#9650;
       </span>
       <span
         class="vdpr-datepicker__calendar-input-time-control-down"
         @click="onClickDown">
-        &#9662;
+        &#9660;
       </span>
     </div>
   </div>

--- a/src/Styles/InputTime.scss
+++ b/src/Styles/InputTime.scss
@@ -34,5 +34,10 @@
         color: black;
       }
     }
+
+    &-up {
+      margin-bottom: -5px;
+      margin-top: 2px;
+    }
   }
 }


### PR DESCRIPTION
I noticed that \&#9652; (▴) and \&#9662; (▾) weren't matching characters.

Had a look around and thought that \&#9650; (▲) and \&#9660; (▼) might work as an alternative, although slightly larger. This replacement required some styling to display nicely.