### PR TITLE
Available dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ Below is values that're available for props "disabled-dates"
 | ranges      | Object          |            | disable dates matching object of date "from" & "to"     |
 | custom      | Function        |            | disable dates with function                             |
 
+If accidentially both disabled dates and available dates are provided, disabled dates take priority.
+
 #### Available Dates
 Below is values that're available for props "available-dates"
 
@@ -148,6 +150,8 @@ Below is values that're available for props "available-dates"
 | to          | Date            |            | allow dates until this date                             |
 | ranges      | Object          |            | allow dates matching object of date "from" & "to"       |
 | custom      | Function        |            | allow dates with function                               |
+
+If accidentially both disabled dates and available dates are provided, disabled dates take priority.
 
 #### Helper Buttons
 Below is values that're available for props "helper-buttons"

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Below is props that're available in **DatePicker** Component
 | format                                | String        | DD/MM/YYYY HH:mm  | Format for display date input                           |
 | [same-date-format](#same-date-format) | Object        | refer below       | Format for display date input if start & end date same  |
 | [disabled-dates](#disabled-dates)     | Object        | refer below       | Disable certain dates                                   |
+| [available-dates](#available-dates)   | Object        | refer below       | Allow only certain dates                                   |
 | [date-input](#date-input)             | Object        |                   | Input configuration                                     |
 | show-helper-buttons                   | Boolean       |                   | Show helper buttons                                     |
 | [helper-buttons](#helper-buttons)     | [ ]Object     |                   | Custom helper button                                    |
@@ -95,6 +96,7 @@ Below is props that're available in **Calendar Dialog** Component
 | inline                                | Boolean         | false       | Use datepicker inline style                 |
 | language                              | String          | en          | Languange                                   |
 | [disabled-dates](#disabled-dates)     | Object          | refer below | Disable certain dates                       |
+| [available-dates](#available-dates)   | Object          | refer below | Allow only certain dates                    |
 | show-helper-buttons                   | Boolean         | true        | Show helper buttons                         |
 | [helper-buttons](#helper-buttons)     | [ ]Object       | [ ]         | Custom helper button                        |
 | [date-input](#c-date-input)           | Object          |             | Calendar input date configuration           |
@@ -135,6 +137,17 @@ Below is values that're available for props "disabled-dates"
 | to          | Date            |            | disable dates until this date                           |
 | ranges      | Object          |            | disable dates matching object of date "from" & "to"     |
 | custom      | Function        |            | disable dates with function                             |
+
+#### Available Dates
+Below is values that're available for props "available-dates"
+
+| Key         | Type            | Default    | Description                                             |
+|-------------|-----------------|------------|---------------------------------------------------------|
+| dates       | [ ]Date         |            | allow dates matching array of Date object               | 
+| from        | Date            |            | allow dates from this date                              |
+| to          | Date            |            | allow dates until this date                             |
+| ranges      | Object          |            | allow dates matching object of date "from" & "to"       |
+| custom      | Function        |            | allow dates with function                               |
 
 #### Helper Buttons
 Below is values that're available for props "helper-buttons"

--- a/example/App.vue
+++ b/example/App.vue
@@ -8,6 +8,8 @@
     <br />
     <example-disabled-dates />
     <br />
+    <example-available-dates />
+    <br />
     <example-helper-buttons />
     <br />
     <example-time-input-config />
@@ -27,6 +29,7 @@
 <script>
 import ExampleEvents from './ExampleEvents.vue';
 import ExampleDisabledDates from './ExampleDisabledDates.vue';
+import ExampleAvailableDates from './ExampleAvailableDates.vue';
 import ExampleHelperButtons from './ExampleHelperButtons.vue';
 import ExampleTimeInputConfig from './ExampleTimeInputConfig.vue';
 import ExampleDateInputConfig from './ExampleDateInputConfig.vue';
@@ -40,6 +43,7 @@ export default {
   components: {
     ExampleEvents,
     ExampleDisabledDates,
+    ExampleAvailableDates,
     ExampleHelperButtons,
     ExampleTimeInputConfig,
     ExampleDateInputConfig,

--- a/example/ExampleAvailableDates.vue
+++ b/example/ExampleAvailableDates.vue
@@ -1,0 +1,106 @@
+<template>
+  <div>
+    <h2>Example Available Dates</h2>
+    <h4>Available date with "to"</h4>
+    <pre>
+      {
+        to : new Date("2020 06 30"),
+      }
+    </pre>
+    <date-picker :dateInput="dateInput" :availableDates="availableDates1a"/>
+    <br />
+    <h4>Available date with "from"</h4>
+    <pre>
+      {
+        from : new Date("2020 08 01"),
+      }
+    </pre>
+    <date-picker :dateInput="dateInput" :availableDates="availableDates1b"/>
+    <br />
+    <h4>Available date with "ranges"</h4>
+    <pre>
+      {
+        ranges: [
+          {
+            from: new Date("2020 05 01"),
+            to: new Date("2020 05 31")
+          },
+          {
+            from: new Date("2020 08 01"),
+            to: new Date("2020 08 31")
+          }
+        ]
+      }
+    </pre>
+    <date-picker :dateInput="dateInput" :availableDates="availableDates2"/>
+    <br />
+    <h4>Available date with "dates"</h4>
+    <pre>
+      {
+        dates: [
+          new Date('2021 08 01'),
+          new Date('2021 07 26'),
+          new Date('2021 08 05'),
+        ]
+      }
+    </pre>
+    <date-picker :dateInput="dateInput" :availableDates="availableDates3"/>
+    <br />
+    <h4>Available date with "custom" function</h4>
+    <pre>
+      {
+        custom: function(date) {
+          return date.getDay() == 1;
+        }
+      }
+    </pre>
+    <date-picker :dateInput="dateInput" :availableDates="availableDates4"/>
+  </div>
+</template>
+
+<script>
+import DatePicker from '../src/Components/DatePicker.vue';
+
+export default {
+  components: {
+    DatePicker,
+  },
+  data() {
+    return {
+      dateInput: {
+        placeholder: 'Select Date',
+      },
+      availableDates1a: {
+        to: new Date('2020 06 30'),
+      },
+      availableDates1b: {
+        from: new Date('2020 08 01'),
+      },
+      availableDates2: {
+        ranges: [
+          {
+            from: new Date('2020 05 01'),
+            to: new Date('2020 05 31'),
+          },
+          {
+            from: new Date('2020 08 01'),
+            to: new Date('2020 08 31'),
+          },
+        ],
+      },
+      availableDates3: {
+        dates: [
+          new Date('2021 08 01'),
+          new Date('2021 07 26'),
+          new Date('2021 08 05'),
+        ],
+      },
+      availableDates4: {
+        custom(date) {
+          return date.getDay() === 1;
+        },
+      },
+    };
+  },
+};
+</script>

--- a/example/ExampleAvailableDates.vue
+++ b/example/ExampleAvailableDates.vue
@@ -90,9 +90,9 @@ export default {
       },
       availableDates3: {
         dates: [
-          new Date('2021 08 01'),
-          new Date('2021 07 26'),
-          new Date('2021 08 05'),
+          new Date('2020 08 01'),
+          new Date('2020 07 26'),
+          new Date('2020 08 05'),
         ],
       },
       availableDates4: {

--- a/example/ExampleAvailableDates.vue
+++ b/example/ExampleAvailableDates.vue
@@ -1,21 +1,14 @@
 <template>
   <div>
     <h2>Example Available Dates</h2>
-    <h4>Available date with "to"</h4>
+    <h4>Available date with "to" and "from"</h4>
     <pre>
       {
         to : new Date("2020 06 30"),
-      }
-    </pre>
-    <date-picker :dateInput="dateInput" :availableDates="availableDates1a"/>
-    <br />
-    <h4>Available date with "from"</h4>
-    <pre>
-      {
         from : new Date("2020 08 01"),
       }
     </pre>
-    <date-picker :dateInput="dateInput" :availableDates="availableDates1b"/>
+    <date-picker :dateInput="dateInput" :availableDates="availableDates1"/>
     <br />
     <h4>Available date with "ranges"</h4>
     <pre>
@@ -70,10 +63,8 @@ export default {
       dateInput: {
         placeholder: 'Select Date',
       },
-      availableDates1a: {
+      availableDates1: {
         to: new Date('2020 06 30'),
-      },
-      availableDates1b: {
         from: new Date('2020 08 01'),
       },
       availableDates2: {

--- a/src/Components/Calendar.vue
+++ b/src/Components/Calendar.vue
@@ -203,11 +203,11 @@ export default {
       );
     },
     isDisabledDate(date) {
-      if (!Util.checkDateObject(this.disabledDates) && !Util.checkDateObject(this.availableDates)) {
+      if (Util.isEmptyObject(this.disabledDates) && Util.isEmptyObject(this.availableDates)) {
         return false;
       }
       let disabled = false;
-      if (Util.checkDateObject(this.disabledDates)) {
+      if (!Util.isEmptyObject(this.disabledDates)) {
         const {
           dates, from, to, ranges, custom,
         } = this.disabledDates;
@@ -247,7 +247,7 @@ export default {
         if (typeof custom === 'function' && custom(date)) {
           disabled = true;
         }
-      } else if (Util.checkDateObject(this.availableDates)) {
+      } else if (!Util.isEmptyObject(this.availableDates)) {
         disabled = true;
         const {
           dates, from, to, ranges, custom,

--- a/src/Components/Calendar.vue
+++ b/src/Components/Calendar.vue
@@ -142,7 +142,12 @@ export default {
           < this.dateUtil.year(pageDate)
         );
       }
-      if (this.availableDates && this.availableDates.to) {
+      if (
+        Util.isEmptyObject(this.disabledDates)
+        && this.availableDates
+        && this.availableDates.to
+        && !this.availableDates.from
+      ) {
         const pageDate = this.dateUtil.fromUnix(this.pageTimestamp);
         return (
           (this.dateUtil.month(this.availableDates.to)
@@ -167,7 +172,12 @@ export default {
           > this.dateUtil.year(pageDate)
         );
       }
-      if (this.availableDates && this.availableDates.from) {
+      if (
+        Util.isEmptyObject(this.disabledDates)
+        && this.availableDates
+        && this.availableDates.from
+        && !this.availableDates.to
+      ) {
         const pageDate = this.dateUtil.fromUnix(this.pageTimestamp);
         return (
           (this.dateUtil.month(this.availableDates.from)

--- a/src/Components/CalendarDialog.vue
+++ b/src/Components/CalendarDialog.vue
@@ -26,6 +26,7 @@
       :selectedStartDate="selectedStartDate"
       :selectedEndDate="selectedEndDate"
       :disabledDates="disabledDates"
+      :availableDates="availableDates"
       :isMondayFirst="isMondayFirst"
       @select-date="selectDate"
       @select-disabled-date="selectDisabledDate"
@@ -134,6 +135,13 @@ export default {
       default: 'en',
     },
     disabledDates: {
+      type: Object,
+      validator: PropsValidator.isValidDisabledDates,
+      default() {
+        return {};
+      },
+    },
+    availableDates: {
       type: Object,
       validator: PropsValidator.isValidDisabledDates,
       default() {

--- a/src/Components/CalendarDialog.vue
+++ b/src/Components/CalendarDialog.vue
@@ -136,14 +136,14 @@ export default {
     },
     disabledDates: {
       type: Object,
-      validator: PropsValidator.isValidDisabledDates,
+      validator: PropsValidator.isValidDateRestriction,
       default() {
         return {};
       },
     },
     availableDates: {
       type: Object,
-      validator: PropsValidator.isValidDisabledDates,
+      validator: PropsValidator.isValidDateRestriction,
       default() {
         return {};
       },

--- a/src/Components/DatePicker.vue
+++ b/src/Components/DatePicker.vue
@@ -21,6 +21,7 @@
       :inline="inline"
       :initialDates="initialDates"
       :disabledDates="disabledDates"
+      :availableDates="availableDates"
       :showHelperButtons="showHelperButtons"
       :helperButtons="helperButtons"
       :dateInput="calendarDateInput"
@@ -89,6 +90,7 @@ export default {
       },
     },
     disabledDates: Object,
+    availableDates: Object,
     showHelperButtons: Boolean,
     helperButtons: Array,
     calendarDateInput: Object,

--- a/src/Utils/PropsValidator.js
+++ b/src/Utils/PropsValidator.js
@@ -39,7 +39,7 @@ export default {
    * @param {Object} value
    * @returns {Boolean}
    */
-  isValidDisabledDates(value) {
+  isValidDateRestriction(value) {
     if (!value || Util.getObjectLength(value) === 0) return true;
 
     const {

--- a/src/Utils/Util.js
+++ b/src/Utils/Util.js
@@ -14,4 +14,19 @@ export default {
    * @returns {Number}
    */
   getObjectLength: (value) => Object.keys(value).length,
+
+  /**
+   * Check disabled/available date object is not empty
+   *
+   * @param {Object} value
+   * @returns {Boolean}
+   */
+  checkDateObject: (value) => {
+    if (value) {
+      if (Object.keys(value).length > 0) {
+        return true;
+      }
+    }
+    return false;
+  },
 };

--- a/src/Utils/Util.js
+++ b/src/Utils/Util.js
@@ -16,17 +16,17 @@ export default {
   getObjectLength: (value) => Object.keys(value).length,
 
   /**
-   * Check disabled/available date object is not empty
+   * Check if disabled/available date object is empty
    *
    * @param {Object} value
    * @returns {Boolean}
    */
-  checkDateObject: (value) => {
+  isEmptyObject: (value) => {
     if (value) {
       if (Object.keys(value).length > 0) {
-        return true;
+        return false;
       }
     }
-    return false;
+    return true;
   },
 };

--- a/test/unit/specs/Calendar/availableDates.spec.js
+++ b/test/unit/specs/Calendar/availableDates.spec.js
@@ -1,0 +1,112 @@
+/* eslint-disable import/no-unresolved */
+import Calendar from '@/Components/Calendar.vue';
+import { shallowMount } from '@vue/test-utils';
+import moment from 'moment';
+import 'regenerator-runtime';
+
+describe('Calendar : Available Dates', () => {
+  const now = new Date();
+  const startOfMonth = moment(now)
+    .startOf('month')
+    .toDate();
+  const endOfMonth = moment(now)
+    .endOf('month')
+    .toDate();
+
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = shallowMount(Calendar);
+  });
+
+  it("should make available dates 'to' a date & 'from' a date availableDates", () => {
+    wrapper.setProps({
+      availableDates: {
+        from: endOfMonth,
+        to: startOfMonth,
+      },
+    });
+
+    const future = moment(now)
+      .add(12, 'y')
+      .toDate();
+    const past = moment(now)
+      .subtract(20, 'y')
+      .toDate();
+
+    expect(wrapper.vm.isNextDisabled).toEqual(true);
+    expect(wrapper.vm.isPrevDisabled).toEqual(true);
+
+    expect(wrapper.vm.isDisabledDate(startOfMonth)).toEqual(false);
+    expect(wrapper.vm.isDisabledDate(future)).toEqual(false);
+    expect(wrapper.vm.isDisabledDate(endOfMonth)).toEqual(false);
+    expect(wrapper.vm.isDisabledDate(past)).toEqual(false);
+  });
+
+  it("can change to available 'to' date & 'from' date", () => {
+    wrapper.setProps({
+      availableDates: {
+        from: endOfMonth,
+        to: startOfMonth,
+      },
+    });
+
+    const monthYear = moment(now).format('MMM YYYY');
+
+    wrapper.vm.onPrevClick();
+    expect(wrapper.vm.monthYear === monthYear).toBe(true);
+    wrapper.vm.onNextClick();
+    expect(wrapper.vm.monthYear === monthYear).toBe(true);
+  });
+
+  it("should allow dates 'dates' from availableDates", () => {
+    wrapper.setProps({
+      availableDates: {
+        dates: [
+          new Date('2020 08 01'),
+          new Date('2020 08 05'),
+          new Date('2020 07 31'),
+        ],
+      },
+    });
+
+    expect(wrapper.vm.isDisabledDate(new Date('2020 08 02'))).toEqual(true);
+    expect(wrapper.vm.isDisabledDate(new Date('2020 08 05'))).toEqual(false);
+    expect(wrapper.vm.isDisabledDate(new Date('2020 07 31'))).toEqual(false);
+  });
+
+  it("should allow dates 'ranges' from availableDates", () => {
+    wrapper.setProps({
+      availableDates: {
+        ranges: [
+          {
+            from: new Date('2020 07 08'),
+            to: new Date('2020 07 18'),
+          },
+          {
+            from: new Date('2023 05 05'),
+            to: new Date('2025 07 27'),
+          },
+        ],
+      },
+    });
+
+    expect(wrapper.vm.isDisabledDate(new Date('2021 01 01'))).toEqual(true);
+    expect(wrapper.vm.isDisabledDate(new Date('2020 07 03'))).toEqual(true);
+    expect(wrapper.vm.isDisabledDate(new Date('2020 07 15'))).toEqual(false);
+    expect(wrapper.vm.isDisabledDate(new Date('2023 08 01'))).toEqual(false);
+  });
+
+  it("should allow date 'custom' function from availableDates", () => {
+    wrapper.setProps({
+      availableDates: {
+        custom: (date) => date.getDate() % 2 === 0 // allow every even date
+        ,
+      },
+    });
+
+    expect(wrapper.vm.isDisabledDate(new Date('2020 01 01'))).toEqual(true);
+    expect(wrapper.vm.isDisabledDate(new Date('2020 01 02'))).toEqual(false);
+    expect(wrapper.vm.isDisabledDate(new Date('2045 05 07'))).toEqual(true);
+  });
+});

--- a/test/unit/specs/Calendar/availableDates.spec.js
+++ b/test/unit/specs/Calendar/availableDates.spec.js
@@ -33,14 +33,63 @@ describe('Calendar : Available Dates', () => {
     const past = moment(now)
       .subtract(20, 'y')
       .toDate();
+    const middleOfMonth = moment(startOfMonth)
+      .add(14, 'd');
+
+    expect(wrapper.vm.isNextDisabled).toEqual(false);
+    expect(wrapper.vm.isPrevDisabled).toEqual(false);
+
+    expect(wrapper.vm.isDisabledDate(startOfMonth)).toEqual(false);
+    expect(wrapper.vm.isDisabledDate(future)).toEqual(false);
+    expect(wrapper.vm.isDisabledDate(middleOfMonth)).toEqual(true);
+    expect(wrapper.vm.isDisabledDate(endOfMonth)).toEqual(false);
+    expect(wrapper.vm.isDisabledDate(past)).toEqual(false);
+  });
+
+  it("should make available dates 'to' a date availableDates", () => {
+    wrapper.setProps({
+      availableDates: {
+        to: endOfMonth,
+      },
+    });
+
+    const future = moment(now)
+      .add(12, 'y')
+      .toDate();
+    const past = moment(now)
+      .subtract(20, 'y')
+      .toDate();
 
     expect(wrapper.vm.isNextDisabled).toEqual(true);
+    expect(wrapper.vm.isPrevDisabled).toEqual(false);
+
+    expect(wrapper.vm.isDisabledDate(startOfMonth)).toEqual(false);
+    expect(wrapper.vm.isDisabledDate(future)).toEqual(true);
+    expect(wrapper.vm.isDisabledDate(endOfMonth)).toEqual(false);
+    expect(wrapper.vm.isDisabledDate(past)).toEqual(false);
+  });
+
+  it("should make available dates 'from' a date availableDates", () => {
+    wrapper.setProps({
+      availableDates: {
+        from: startOfMonth,
+      },
+    });
+
+    const future = moment(now)
+      .add(12, 'y')
+      .toDate();
+    const past = moment(now)
+      .subtract(20, 'y')
+      .toDate();
+
+    expect(wrapper.vm.isNextDisabled).toEqual(false);
     expect(wrapper.vm.isPrevDisabled).toEqual(true);
 
     expect(wrapper.vm.isDisabledDate(startOfMonth)).toEqual(false);
     expect(wrapper.vm.isDisabledDate(future)).toEqual(false);
     expect(wrapper.vm.isDisabledDate(endOfMonth)).toEqual(false);
-    expect(wrapper.vm.isDisabledDate(past)).toEqual(false);
+    expect(wrapper.vm.isDisabledDate(past)).toEqual(true);
   });
 
   it("can change to available 'to' date & 'from' date", () => {
@@ -54,9 +103,11 @@ describe('Calendar : Available Dates', () => {
     const monthYear = moment(now).format('MMM YYYY');
 
     wrapper.vm.onPrevClick();
-    expect(wrapper.vm.monthYear === monthYear).toBe(true);
+    expect(wrapper.vm.monthYear === monthYear).toBe(false);
     wrapper.vm.onNextClick();
     expect(wrapper.vm.monthYear === monthYear).toBe(true);
+    wrapper.vm.onNextClick();
+    expect(wrapper.vm.monthYear === monthYear).toBe(false);
   });
 
   it("should allow dates 'dates' from availableDates", () => {
@@ -108,5 +159,31 @@ describe('Calendar : Available Dates', () => {
     expect(wrapper.vm.isDisabledDate(new Date('2020 01 01'))).toEqual(true);
     expect(wrapper.vm.isDisabledDate(new Date('2020 01 02'))).toEqual(false);
     expect(wrapper.vm.isDisabledDate(new Date('2045 05 07'))).toEqual(true);
+  });
+
+  it('should ignore availableDates if disabledDates is provided', () => {
+    wrapper.setProps({
+      availableDates: {
+        from: endOfMonth,
+      },
+      disabledDates: {
+        from: endOfMonth,
+      },
+    });
+
+    const future = moment(now)
+      .add(12, 'y')
+      .toDate();
+    const past = moment(now)
+      .subtract(20, 'y')
+      .toDate();
+
+    expect(wrapper.vm.isNextDisabled).toEqual(true);
+    expect(wrapper.vm.isPrevDisabled).toEqual(false);
+
+    expect(wrapper.vm.isDisabledDate(startOfMonth)).toEqual(false);
+    expect(wrapper.vm.isDisabledDate(future)).toEqual(true);
+    expect(wrapper.vm.isDisabledDate(endOfMonth)).toEqual(true);
+    expect(wrapper.vm.isDisabledDate(past)).toEqual(false);
   });
 });

--- a/test/unit/specs/Calendar/disabledDates.spec.js
+++ b/test/unit/specs/Calendar/disabledDates.spec.js
@@ -39,12 +39,15 @@ describe('Calendar : Disabled Dates', () => {
     const past = moment(now)
       .subtract(20, 'y')
       .toDate();
+    const middleOfMonth = moment(startOfMonth)
+      .add(14, 'd');
 
     expect(wrapper.vm.isNextDisabled).toEqual(true);
     expect(wrapper.vm.isPrevDisabled).toEqual(true);
 
     expect(wrapper.vm.isDisabledDate(startOfMonth)).toEqual(true);
     expect(wrapper.vm.isDisabledDate(future)).toEqual(true);
+    expect(wrapper.vm.isDisabledDate(middleOfMonth)).toEqual(false);
     expect(wrapper.vm.isDisabledDate(endOfMonth)).toEqual(true);
     expect(wrapper.vm.isDisabledDate(past)).toEqual(true);
   });

--- a/test/unit/specs/PropsValidator.spec.js
+++ b/test/unit/specs/PropsValidator.spec.js
@@ -61,38 +61,38 @@ describe('Props Validator', () => {
     expect(isValid).toBe(false);
   });
 
-  it('isValidDisabledDates should return true if no parameter or empty object', () => {
-    expect(PropsValidator.isValidDisabledDates()).toBe(true);
+  it('isValidDateRestriction should return true if no parameter or empty object', () => {
+    expect(PropsValidator.isValidDateRestriction()).toBe(true);
 
-    expect(PropsValidator.isValidDisabledDates({})).toBe(true);
+    expect(PropsValidator.isValidDateRestriction({})).toBe(true);
   });
 
-  it('isValidDisabledDates should return false if dates items is not date', () => {
-    const isValid = PropsValidator.isValidDisabledDates({
+  it('isValidDateRestriction should return false if dates items is not date', () => {
+    const isValid = PropsValidator.isValidDateRestriction({
       dates: ['2020-10-15'],
     });
 
     expect(isValid).toBe(false);
   });
 
-  it('isValidDisabledDates should return false if from is not date', () => {
-    const isValid = PropsValidator.isValidDisabledDates({
+  it('isValidDateRestriction should return false if from is not date', () => {
+    const isValid = PropsValidator.isValidDateRestriction({
       from: '2020-10-15',
     });
 
     expect(isValid).toBe(false);
   });
 
-  it('isValidDisabledDates should return false if to is not date', () => {
-    const isValid = PropsValidator.isValidDisabledDates({
+  it('isValidDateRestriction should return false if to is not date', () => {
+    const isValid = PropsValidator.isValidDateRestriction({
       to: '2020-10-15',
     });
 
     expect(isValid).toBe(false);
   });
 
-  it('isValidDisabledDates should return false if ranges is not valid', () => {
-    let isValid = PropsValidator.isValidDisabledDates({
+  it('isValidDateRestriction should return false if ranges is not valid', () => {
+    let isValid = PropsValidator.isValidDateRestriction({
       ranges: [
         {
           from: '2020-10-15',
@@ -103,7 +103,7 @@ describe('Props Validator', () => {
 
     expect(isValid).toBe(false);
 
-    isValid = PropsValidator.isValidDisabledDates({
+    isValid = PropsValidator.isValidDateRestriction({
       ranges: [
         {
           from: new Date('2020-10-15'),
@@ -115,16 +115,16 @@ describe('Props Validator', () => {
     expect(isValid).toBe(false);
   });
 
-  it('isValidDisabledDates should return false if custom is not function', () => {
-    const isValid = PropsValidator.isValidDisabledDates({
+  it('isValidDateRestriction should return false if custom is not function', () => {
+    const isValid = PropsValidator.isValidDateRestriction({
       custom: new Date('2020-10-15'),
     });
 
     expect(isValid).toBe(false);
   });
 
-  it('isValidDisabledDates should return true if all props is valid', () => {
-    const isValid = PropsValidator.isValidDisabledDates({
+  it('isValidDateRestriction should return true if all props is valid', () => {
+    const isValid = PropsValidator.isValidDateRestriction({
       dates: [new Date('2020-10-15')],
       from: new Date('2020-12-01'),
       to: new Date('2020-07-30'),


### PR DESCRIPTION
I needed to allow several specific date ranges, so implementations support for this and figured it might be worth feeding back into the main repo.

---

**Overview of changes:**

- The structure used by `disabled-dates` has been replicated as closely as possible, to hopefully add some consistency. 

- The `isValidDisabledDates` prop validator has been reused (which might be better renamed if it's reused?).

- One difference compared to how the `disabled-dates` work is that the use of both `from` and `to` keys at the same time is not entirely supported. This seemed like a reasonable compromise given that if a specific period is disabled then the `disabled-dates` prop can be used. Open to suggestions.

- To check if `disabled-dates` or `available-dates` contain valid properties rather than just an empty object, a `checkDateObject` function has been added to the `Utils`. Perhaps this is better placed elsewhere, or the contents of the props checked in a different way?

- To ensure no breaking changes, disabled dates will take priority if both props are provided.

---

Also spotted a bug in the `isNextDisabled` and `isPrevDisabled` which has been fixed as part of this. It can easily be submitted in a separate PR if it's helpful to integrate that sooner or without integrating these changes.

I've tried to remember to run lint before committing this time 😄  but didn't appear to do much, so might be worth checking.

Let me know what your thought are on this overall @limbara.